### PR TITLE
Example: Migrate the build configuration from Groovy to KTS

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,84 +1,106 @@
 plugins {
-    id 'com.android.application'
-    id 'kotlin-android'
+    id("com.android.application")
+    id("kotlin-android")
+}
+
+private object BuildTypes {
+    const val DEBUG = "debug"
+    const val RELEASE = "release"
+    const val STAGING = "staging"
+
+    const val DEV = "dev"
+    const val STG = "stg"
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion(30)
+    buildToolsVersion = "30.0.2"
 
     defaultConfig {
-        applicationId "com.android.gradlekts"
-        minSdkVersion minSdk
-        targetSdkVersion targetSdk
-        versionCode verCode
-        versionName verName
+        applicationId = "com.android.gradlekts"
+        minSdkVersion(Versions.minAndroidSdk)
+        targetSdkVersion(Versions.targetSdkVersion)
+        versionCode = Versions.verCode
+        versionName = Versions.verName
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField("String", "API_URL", "\"https://api.github.com/\"")
     }
 
     signingConfigs {
-        release {
-            keyAlias KeyAlias
-            keyPassword KeyPassword
-            storeFile file(StoreFile)
-            storePassword StorePassword
-            v1SigningEnabled true
-            v2SigningEnabled true
+        create(BuildTypes.RELEASE) {
+            keyAlias = Signing.KeyAlias
+            keyPassword = Signing.KeyPassword
+            storeFile = File(Signing.StoreFile)
+            storePassword = Signing.StorePassword
+            isV1SigningEnabled = true
+            isV2SigningEnabled = true
         }
     }
 
 
     buildTypes {
-        all {
-            buildConfigField("String", "API_URL", "\"https://api.github.com/\"")
-        }
-        debug {
-            minifyEnabled false
-            testCoverageEnabled project.hasProperty("coverage")
-            debuggable true
-            applicationIdSuffix ".dev"
-            versionNameSuffix "-DEV"
-            signingConfig signingConfigs.debug
+        getByName(BuildTypes.DEBUG) {
+            isMinifyEnabled = false
+            isTestCoverageEnabled = project.hasProperty("coverage")
+            isDebuggable = true
+            applicationIdSuffix = ".${BuildTypes.DEV}"
+            versionNameSuffix = "-${BuildTypes.DEV.toUpperCase()}"
+            signingConfig = signingConfigs.getByName(BuildTypes.DEBUG)
+            buildConfigField("String", "BASE_URL", "\"https://comdev.example.com/\"")
         }
 
-        release {
-            minifyEnabled false
-            shrinkResources false
-            debuggable false
-            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
-            signingConfig signingConfigs.release
+        getByName(BuildTypes.RELEASE)  {
+            isMinifyEnabled = false
+            isShrinkResources = false
+            isDebuggable = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            signingConfig = signingConfigs.getByName(BuildTypes.RELEASE)
+            buildConfigField("String", "BASE_URL", "\"https://com.example.com/\"")
+        }
+
+        // if you want to add other buildType, that will do example:
+        create(BuildTypes.STAGING) {
+            isMinifyEnabled = false
+            isShrinkResources = false
+            isDebuggable = false
+            applicationIdSuffix = ".${BuildTypes.STG}"
+            versionNameSuffix = "-${BuildTypes.STG.toUpperCase()}"
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            signingConfig = signingConfigs.getByName(BuildTypes.RELEASE)
+
+            buildConfigField("String", "BASE_URL", "\"https://comstg.example.com/\"")
         }
     }
 
-    flavorDimensions "default"
+    flavorDimensions("default")
     productFlavors {
-        google {
-        }
-        other {
-        }
+        create("google")
+        create("other")
     }
     productFlavors.all {
-        flavor -> flavor.manifestPlaceholders = [CHANNEL_VALUE: name]
+        manifestPlaceholders["CHANNEL_VALUE"] = name
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 
 dependencies {
+    implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "androidx.core:core-ktx:$core_ktx_version"
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:${Libs.KOTLIN_VERSION}")
+    implementation("androidx.core:core-ktx:${Libs.CORE_KTX_VERSION}")
+    implementation("androidx.appcompat:appcompat:1.3.1")
+    implementation("com.google.android.material:material:1.4.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.0")
+    testImplementation("junit:junit:4.+")
+    androidTestImplementation("androidx.test.ext:junit:1.1.3")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,23 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 
-    ext{
-        kotlin_version = "1.3.72"
-        core_ktx_version = "1.6.0"
-
-        minSdk = 21
-        targetSdk = 30
-        verCode = 100     // XYZ
-        verName = "1.0.0" // X.Y.Z; X = Major, Y = minor, Z = Patch level
-    }
-
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath("com.android.tools.build:gradle:4.1.2")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Libs.KOTLIN_VERSION}")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -31,8 +21,6 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register("clean", Delete::class){
+    delete(rootProject.buildDir)
 }
-
-apply from: "signing.gradle"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,8 @@
+// build.gradle.kts
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    gradlePluginPortal()
+}

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -1,0 +1,6 @@
+object Libs {
+    const val KOTLIN_VERSION = "1.3.72"
+    const val CORE_KTX_VERSION = "1.6.0"
+    const val GOOGLE_OSS_VERSION = "0.10.2"
+    const val GOOGLE_SERVICES_VERSION = "4.3.3"
+}

--- a/buildSrc/src/main/kotlin/Signing.kt
+++ b/buildSrc/src/main/kotlin/Signing.kt
@@ -1,0 +1,6 @@
+object Signing {
+    const val StoreFile = "../test.keystore"
+    const val StorePassword = "123456"
+    const val KeyAlias = "test"
+    const val KeyPassword = "123456"
+}

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,0 +1,6 @@
+object Versions {
+    const val minAndroidSdk = 21
+    const val targetSdkVersion = 30
+    const val verCode = 100     // XYZ
+    const val verName = "1.0.0" // X.Y.Z; X = Major, Y = minor, Z = Patch level
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,4 @@
-include ':app'
+include(
+    ":app"
+)
 rootProject.name = "GradleKTSExample"

--- a/signing.gradle
+++ b/signing.gradle
@@ -1,6 +1,0 @@
-ext {
-    StoreFile = "../test.keystore"
-    StorePassword = "123456"
-    KeyAlias = "test"
-    KeyPassword = "123456"
-}


### PR DESCRIPTION
- unifying quotes using double quotes.

- disambiguating function invocations and property assignments (using respectively parentheses and assignment operator).

- buildTypes (such as debug and release) are implicitly provided, other buildTypes must be created manually.

- Add buildSrc for ext.

- Delete gradle of ext.